### PR TITLE
Update package discovery method and bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,13 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["landlensdb"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["landlensdb*"]
 
 [project]
 name = "landlensdb"
-version = "0.1.0"
+version = "0.1.1"
 description = "Geospatial image handling and management"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Replaced static package definition with dynamic discovery using `setuptools.find`. This enhances flexibility by automatically including all relevant subpackages. Incremented version to 0.1.1 to reflect this change.