### PR TITLE
Update version to 0.1.2 and modify image geotagging behavior

### DIFF
--- a/landlensdb/handlers/image.py
+++ b/landlensdb/handlers/image.py
@@ -329,9 +329,7 @@ class Local:
                         geotags = cls._get_geotagging(exif_data)
                         lat, lon = cls._get_coordinates(geotags)
                         if lat is None or lon is None:
-                            raise ValueError(
-                                f"Invalid coordinates for {filepath}: Latitude: {lat}, Longitude: {lon}"
-                            )
+                            warnings.warn(f"Skipping {filepath}: No valid GPS coordinates (lat={lat}, lon={lon})")
                         geometry = Point(lon, lat)
                     except Exception as e:
                         warnings.warn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["landlensdb*"]
 
 [project]
 name = "landlensdb"
-version = "0.1.1"
+version = "0.1.2"
 description = "Geospatial image handling and management"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bumped the version in pyproject.toml to 0.1.2. Replaced a raised exception with a warning in image handler for files with invalid GPS coordinates, ensuring smoother processing by skipping problematic files instead of halting execution.